### PR TITLE
Apply UI scaling if configured in desktop environment

### DIFF
--- a/src/BagInspectorApp.cpp
+++ b/src/BagInspectorApp.cpp
@@ -210,7 +210,7 @@ void BagInspectorApp::render_timeline_tab()
     const size_t n_topics = m_data.topics.size();
 
     // Left panel: topic list with visibility toggles
-    ImGui::BeginChild("topic_list", ImVec2(220, 0), ImGuiChildFlags_Border);
+    ImGui::BeginChild("topic_list", ImVec2(220 * m_dpi_scaling_factor, 0), ImGuiChildFlags_Border);
     ImGui::Text("Topics (%zu)", n_topics);
     ImGui::Separator();
 

--- a/src/BagInspectorApp.hpp
+++ b/src/BagInspectorApp.hpp
@@ -38,6 +38,8 @@ class BagInspectorApp
 
     bool wants_quit() const { return m_wants_quit; }
 
+    void set_dpi_scaling_factor(float scaling_factor) { m_dpi_scaling_factor = scaling_factor; };
+
    private:
     void render_timeline_tab();
     void render_histograms_tab();
@@ -65,4 +67,6 @@ class BagInspectorApp
     bool        m_show_status_modal = false;
 
     bool m_wants_quit = false;
+
+    float m_dpi_scaling_factor = 1.0;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,20 @@ int main(int argc, char** argv)
     glfwMakeContextCurrent(window);
     glfwSwapInterval(1);
 
+    // Query UI scaling factor for high dpi monitors
+    float dpi_scaling_factor = 1.0;
+    {
+        GLFWmonitor *monitor = glfwGetPrimaryMonitor();
+        float xscale = 1.0;
+        float yscale = 1.0;
+        glfwGetMonitorContentScale(monitor, &xscale, &yscale);
+        if (xscale > 1 || yscale > 1)
+        {
+            dpi_scaling_factor = xscale;
+            glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
+        }
+    }
+
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
     ImPlot::CreateContext();
@@ -56,6 +70,11 @@ int main(int argc, char** argv)
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
 
     ImGui::StyleColorsDark();
+    // Apply dpi scaling factor to ImGui style and default font
+    ImGui::GetStyle().ScaleAllSizes(dpi_scaling_factor);
+    ImFontConfig config;
+    config.SizePixels = 13.0f * dpi_scaling_factor;
+    ImGui::GetIO().Fonts->AddFontDefault(&config);
 
     ImGui_ImplGlfw_InitForOpenGL(window, true);
     ImGui_ImplOpenGL3_Init(glsl_version);
@@ -65,6 +84,8 @@ int main(int argc, char** argv)
     {
         app.load_bag(initial_bag_path);
     }
+
+    app.set_dpi_scaling_factor(dpi_scaling_factor);
 
     while (!glfwWindowShouldClose(window) && !app.wants_quit())
     {


### PR DESCRIPTION
Hi, thank you for sharing this useful tool!

I made some changes such that the UI is scaled appropriately if a scaling is configured in the system settings, as otherwise all text and UI elements were unusably small on my monitor, and wanted to share them, feel free to pull them if this seems useful to you as well!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced high-DPI display support: The application now automatically detects the monitor's DPI scaling factor at startup and applies proportional scaling to all interface elements, fonts, and layout components. This ensures optimal visibility, readability, and usability on modern high-resolution and high-DPI displays without requiring manual configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->